### PR TITLE
Add board edge glow particle effect to voxel world

### DIFF
--- a/src/components/stable-happiness-v3.9/MainCanvas.jsx
+++ b/src/components/stable-happiness-v3.9/MainCanvas.jsx
@@ -7,6 +7,7 @@ import * as THREE from "three";
 import {
     buildVoxelWorld, createSword, buildFairyAura, buildFairyCore,
     buildFlourish, buildSparkExplosion, buildAmbient, buildTextSystem,
+    buildBoardEdgeGlow,
 } from "./builders";
 
 export default function MainCanvas({ scrollProgress, activeSection, sections }) {
@@ -51,6 +52,7 @@ export default function MainCanvas({ scrollProgress, activeSection, sections }) 
 
         // Build world
         const voxels = buildVoxelWorld(scene);
+        const edgeGlow = buildBoardEdgeGlow(voxels.group);
         const ambient = buildAmbient(scene);
 
         // Build fairy systems + text
@@ -120,6 +122,8 @@ export default function MainCanvas({ scrollProgress, activeSection, sections }) 
             voxels.mesh.instanceMatrix.needsUpdate = true;
             voxels.group.rotation.y = 0.3 + t * 0.001 + sp * 0.35;
             voxels.group.position.y = -9 - sp * 1.5;
+
+            edgeGlow.mat.uniforms.uTime.value = t;
 
             ambient.mat.uniforms.uTime.value = t;
             ambient.mat.uniforms.uScroll.value = sp;

--- a/src/components/stable-happiness-v3.9/index.js
+++ b/src/components/stable-happiness-v3.9/index.js
@@ -18,6 +18,7 @@ export { default as MainCanvas } from "./MainCanvas";
 // Builders for custom scenes
 export {
     buildVoxelWorld,
+    buildBoardEdgeGlow,
     createSword,
     buildFairyAura,
     buildFairyCore,
@@ -34,6 +35,7 @@ export {
     FAIRY_VERT, FAIRY_FRAG,
     FLOURISH_VERT, FLOURISH_FRAG,
     SPARK_VERT, SPARK_FRAG,
+    EDGE_GLOW_VERT, EDGE_GLOW_FRAG,
     AMB_VERT, AMB_FRAG,
 } from "./shaders";
 


### PR DESCRIPTION
## Summary
This PR adds a new particle-based glow effect that radiates from the edges of the voxel board, creating a warm, ambient radiance around the perimeter. The effect uses custom shaders to animate particles drifting outward from each of the four board edges with smooth fade-in/fade-out cycles and gentle color variations.

## Key Changes
- **New shader system**: Added `EDGE_GLOW_VERT` and `EDGE_GLOW_FRAG` shaders that handle particle lifecycle, drift direction, color blending (gold → amber → rose), and soft radial glow rendering
- **New builder function**: `buildBoardEdgeGlow()` creates 400 particles (100 per edge) positioned along the four board edges with randomized sizes, phases, and directional vectors
- **Integration**: Instantiated the edge glow effect in `MainCanvas` and wired up the `uTime` uniform to drive particle animations
- **Exports**: Updated module exports in `index.js` to expose the new builder and shaders

## Implementation Details
- Particles are distributed across four edges (front, back, left, right) with edge-specific outward radiation directions
- Each particle has a 6-second lifecycle with smooth fade-in (0-15% of life) and fade-out (50-100% of life)
- Particles drift outward at 1.8 units/second, rise gently, and sway with sine/cosine oscillations
- Color is dynamically blended between warm gold, soft amber, and faint rose based on particle phase and edge index
- Uses additive blending and disables depth writes for a soft, ethereal appearance
- Soft radial falloff in fragment shader creates a comfortable glow without harsh edges

https://claude.ai/code/session_01PbxKCxzRL33D88x1TW4iT8